### PR TITLE
Add website link to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Suggests:
     knitr,
     rmarkdown,
     markdown (>= 1.3)
-URL: https://github.com/radiant-rstats/radiant
+URL: https://radiant-rstats.github.io/docs/, https://github.com/radiant-rstats/radiant
 BugReports: https://github.com/radiant-rstats/radiant/issues
 License: AGPL-3 | file LICENSE
 Encoding: UTF-8


### PR DESCRIPTION
for discoverability. Still think this is worth adding https://blog.r-hub.io/2019/12/10/urls/, but closing stale PRs